### PR TITLE
Update vulnerable and deprecated dependencies

### DIFF
--- a/lib/in-memory.js
+++ b/lib/in-memory.js
@@ -1,6 +1,6 @@
 module.exports = InMemory
 
-var uuid = require('node')
+var uuid = require('uuid')
 
 function InMemory (opts) {
   opts = opts || {}

--- a/lib/in-memory.js
+++ b/lib/in-memory.js
@@ -1,6 +1,6 @@
 module.exports = InMemory
 
-var uuid = require('node-uuid')
+var uuid = require('node')
 
 function InMemory (opts) {
   opts = opts || {}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha ./test/*.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/solid/node-solid-ws"
+  },
   "keywords": [
     "solid",
     "websockets",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^2.2.0",
-    "node-uuid": "^1.4.3",
     "run-parallel": "^1.1.4",
+    "uuid": "^3.0.1",
     "ws": "^0.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "debug": "^2.2.0",
     "run-parallel": "^1.1.4",
     "uuid": "^3.0.1",
-    "ws": "^0.8.0"
+    "ws": "^1.1.1"
   },
   "devDependencies": {
     "chai": "^3.3.0",


### PR DESCRIPTION
* Update ws to latest (1.1.1), addresses https://snyk.io/vuln/npm:ws:20160624 and https://snyk.io/vuln/npm:ws:20160104
* Switch deprecated `node-uuid` package to `uuid` which replaces it. (Will get rid of deprecation warnings when installing node-solid-server).
* Added a `repository` property to package.json