### PR TITLE
Avoid public notifications about private resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
+  - "10"

--- a/index.js
+++ b/index.js
@@ -4,15 +4,20 @@ var path = require('path')
 
 module.exports = function attachToServer (server, app, opts) {
   var solidWs = new SolidWs(server, opts)
-
   function publish (req, res, next) {
-    debug('pub ' + req.originalUrl + ' after edit')
-    solidWs.publish(req.originalUrl)
-    var parent = path.dirname(req.originalUrl) + path.sep
-    if (parent !== req.originalUrl) {
-      solidWs.publish(parent)
-    }
-    next()
+    req.acl.can(null, 'Read').then(isPublic => {
+      if (isPublic) {
+        debug('pub ' + req.originalUrl + ' after edit')
+        solidWs.publish(req.originalUrl)
+        var parent = path.dirname(req.originalUrl) + path.sep
+        if (parent !== req.originalUrl) {
+          solidWs.publish(parent)
+        }
+      } else {
+        debug('do not pub ' + req.originalUrl + ' after edit')
+      }
+      next()
+    })
   }
 
   if (app) {

--- a/index.js
+++ b/index.js
@@ -5,44 +5,21 @@ var path = require('path')
 module.exports = function attachToServer (server, app, opts) {
   var solidWs = new SolidWs(server, opts)
 
-  if (app) {
+  function publish (req, res, next) {
+    debug('pub ' + req.originalUrl + ' after edit')
+    solidWs.publish(req.originalUrl)
+    var parent = path.dirname(req.originalUrl) + path.sep
+    if (parent !== req.originalUrl) {
+      solidWs.publish(parent)
+    }
+    next()
+  }
 
-    app.post('/*', function (req, res, next) {
-      debug('pub ' + req.originalUrl + ' after post')
-      solidWs.publish(req.originalUrl)
-      var parent = path.dirname(req.originalUrl) + path.sep
-      if (parent !== req.originalUrl) {
-        solidWs.publish(parent)
-      }
-      next()
-    })
-    app.patch('/*', function (req, res, next) {
-      debug('pub ' + req.originalUrl + ' after patch')
-      solidWs.publish(req.originalUrl)
-      var parent = path.dirname(req.originalUrl) + path.sep
-      if (parent !== req.originalUrl) {
-        solidWs.publish(parent)
-      }
-      next()
-    })
-    app.put('/*', function (req, res, next) {
-      debug('pub ' + req.originalUrl + ' after put')
-      solidWs.publish(req.originalUrl)
-      var parent = path.dirname(req.originalUrl) + path.sep
-      if (parent !== req.originalUrl) {
-        solidWs.publish(parent)
-      }
-      next()
-    })
-    app.delete('/*', function (req, res, next) {
-      debug('pub ' + req.originalUrl + ' after delete')
-      solidWs.publish(req.originalUrl)
-      var parent = path.dirname(req.originalUrl) + path.sep
-      if (parent !== req.originalUrl) {
-        solidWs.publish(parent)
-      }
-      next()
-    })
+  if (app) {
+    app.post('/*', publish)
+    app.patch('/*', publish)
+    app.put('/*', publish)
+    app.delete('/*', publish)
   }
 
   return solidWs


### PR DESCRIPTION
This is a first step of two for fixing #1. First, since currently WebSocket client connections are all unauthenticated, none of them should receive notifications about non-public resources.

In a follow-up PR, we should add code to check and store credentials of WebSocket clients, and then allow them to receive updates about non-public resources too, based on those credentials.